### PR TITLE
Add support for latest kernel driver and dynamic MAC address

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@ This program allows the user to adjust color and brightness to the various LEDs 
 
 ## Prerequisites (besides your DS, obviously)
 * Linux-based operating system
-* Sony's official driver for the DualSense, available in the [AUR](https://aur.archlinux.org/packages/hid-playstation-dkms). As it's not in the kernel yet, you'll need to otherwise download the [patches](https://patchwork.kernel.org/project/linux-input/list/?series=404369) and compile the kernel
-* Access to root privileges (the program modifies the values found in `sys/class/leds/playstation::[mac_address]::[name_of_LED]/`)
+* Access to root privileges (the program modifies the values found in `/sys/devices`)
 * Python 3
 * GTK 3
 * Tkinter
@@ -24,9 +23,7 @@ Other tasks going on on your computer will still run regardless.
 
 ## How To Use
 1. Clone the repository, i.e. `git clone https://github.com/cow-killer/dualsense-led-configurator.git`
-2. Plug your DS in or connect it via Bluetooth, then take note of its MAC address (can be found in `sys/class/leds/`)
-3. Open `ds_led.py` with a text editor, and fill in the MAC address at or somewhere near line 16
-4. Save the file, then run the script as root: `sudo python ds_led.py`
+2. Run the script as root: `sudo python ds_led.py`
 
 ## To-Do
 * ~~Code is a mess, more than likely a way to reduce the amount of code needed~~ Thanks thats-the-joke!

--- a/ds_led.py
+++ b/ds_led.py
@@ -11,7 +11,7 @@ import sys  # for exiting the application if there is an error
 import os  # detects if program is being run as root
 import select
 import tkinter.colorchooser  # need tkiner for now for color picker and RGB brightness
-import subprocess
+import subprocess  # for running Linux commands
 
 # find the path to the ps-controller-battery directory
 device_path = subprocess.check_output(["find", "/sys/devices/","-name","ps-controller-battery*"])
@@ -103,7 +103,7 @@ class MainWindow(Gtk.Window):
             )
         except FileNotFoundError:
             print(
-                "ERROR: You either entered the wrong MAC address or your device is not connected."
+                "ERROR: Your controller can't be detected."
             )
             sys.exit()
         else:

--- a/ds_led.py
+++ b/ds_led.py
@@ -13,13 +13,18 @@ import select
 import tkinter.colorchooser  # need tkiner for now for color picker and RGB brightness
 import subprocess
 
+# find the path to the ps-controller-battery directory
 device_path = subprocess.check_output(["find", "/sys/devices/","-name","ps-controller-battery*"])
+# extract the MAC address from the filepath
 mac_address = device_path.decode().split("/")[-1].split("-")[-1].strip()
-device_path = "/".join(device_path.decode().split("/")[0:10])
+# extract the main controller directory
+device_path = "/".join(device_path.decode().split("/")[0:-2])
 
+# get the random two-digit number assigned to the contoller
 input_num = subprocess.check_output(["find", "/sys/devices/", "-name", "input??:white:player-1"])
 input_num = input_num.decode().split("/")[-1][5:7]
 
+# create useful variables for other controller subsystems
 battery_path = f"{device_path}/power_supply/ps-controller-battery-{mac_address}"
 player_leds_path = f"{device_path}/leds/input{input_num}:white:player"
 rgb_leds_path = f"{device_path}/leds/input{input_num}:rgb:indicator"

--- a/ds_led.py
+++ b/ds_led.py
@@ -20,9 +20,9 @@ mac_address = device_path.decode().split("/")[-1].split("-")[-1].strip()
 # extract the main controller directory
 device_path = "/".join(device_path.decode().split("/")[0:-2])
 
-# get the random two-digit number assigned to the contoller
-input_num = subprocess.check_output(["find", "/sys/devices/", "-name", "input??:white:player-1"])
-input_num = input_num.decode().split("/")[-1][5:7]
+# get the random number assigned to the contoller
+input_num = subprocess.check_output(["find", "/sys/devices/", "-name", "input*:white:player-1"])
+input_num = input_num.decode().split("/")[-1].split(":")[0][5:]
 
 # create useful variables for other controller subsystems
 battery_path = f"{device_path}/power_supply/ps-controller-battery-{mac_address}"


### PR DESCRIPTION
This PR adds support for latest Dualsense Driver in the current kernel version. I've tested this on my machine using the 5.16.0 kernel. The controller is exposed in a different directory, within `/sys/devices`. For example, one of my controllers is at `/sys/devices/pci0000:00/0000:00:08.1/0000:05:00.3/usb1/1-3/1-3:1.3/0003:054C:0CE6.000A/`.

I've added automatic controller path discovery, using the `find` GNU command within the `subprocess` Python module. This method also removes the need for the user to enter the MAC address of their device. However, it must be noted that **the user cannot configure more than one controller at a time**.

Finally, I've removed some magic strings regarding the paths and extracted them to variables.